### PR TITLE
Add an opiton for user to choose whether to compile

### DIFF
--- a/src/cmd/creation-details.ts
+++ b/src/cmd/creation-details.ts
@@ -61,8 +61,6 @@ async function creationDetails(rawArg: any) {
 
   printSeparator();
 
-  const res = await creation.getResourceData();
-
   // Do the check first. Corner case when the transaction was not executed last
   // time even enough signature was collected.
   const userBreak = await checkCreationEnoughSigsAndAssemble(creation);

--- a/src/cmd/main.ts
+++ b/src/cmd/main.ts
@@ -1,4 +1,5 @@
 // TODO: Any coin decimal
+// TODO: Remove compile option from move publish
 // TODO: handle transaction execution error during assemble and submit
 // TODO: View assets list (get from resources) and coin transfer
 // TODO: More customized parameters, e.g. gas price, max price, expiration, e.t.c

--- a/src/cmd/main.ts
+++ b/src/cmd/main.ts
@@ -1,5 +1,4 @@
 // TODO: Any coin decimal
-// TODO: Remove compile option from move publish
 // TODO: handle transaction execution error during assemble and submit
 // TODO: View assets list (get from resources) and coin transfer
 // TODO: More customized parameters, e.g. gas price, max price, expiration, e.t.c

--- a/src/momentum-safe/move-publisher.ts
+++ b/src/momentum-safe/move-publisher.ts
@@ -43,14 +43,17 @@ type NamedAddress = {
 export class MovePublisher {
   constructor(public readonly moveInfo: MoveProject) { }
 
-  static async fromMoveDir(
-    moveDir: string,
-    artifacts: IncludedArtifacts,
-    namedAddress: NamedAddress,
-  ): Promise<MovePublisher> {
-    await MovePublisher.moveCompile(moveDir, artifacts, namedAddress);
+  static async fromMoveDir(moveDir: string) {
     const moveInfo = MovePublisher.loadCompiledMoveProject(moveDir);
     return new MovePublisher(moveInfo);
+  }
+
+  static async compile(
+    moveDir: string,
+    artifacts: IncludedArtifacts,
+    namedAddress: NamedAddress
+  ) {
+    await MovePublisher.moveCompile(moveDir, artifacts, namedAddress);
   }
 
   getDeployTransaction(sender: HexString, config: Options) {


### PR DESCRIPTION
# Description

According to the feedbacks from @borispovod, add an option for user to choose whether to compile the move module before publish. The compile is default to NO. Also added several lines of prompt for action items for custom compiles.

```
Start Module publish

Do you want to compile the MOVE module? [y/N]

Publish move modules.

Please confirm for prerequisite:
	1. MOVE module has already been compiled with flag `--save-metadata`
	2. The deployer's address has been set to momentum safe 0xa39656a1c999d9eae83b5c9824dc0c9118dd9f088d0471d73cbf29cbff73420b
```




