### PR TITLE
support event query

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/mocha": "^9.1.1",
     "@types/readline-sync": "^1.4.4",
-    "aptos": "^1.3.13",
+    "aptos": "^1.3.15",
     "bignumber": "^1.1.0",
     "buffer": "^6.0.3",
     "chai": "^4.3.6",

--- a/src/momentum-safe/common.ts
+++ b/src/momentum-safe/common.ts
@@ -1,4 +1,5 @@
-import {APTOS_COIN, BCS, HexString, TxnBuilderTypes} from "aptos";
+import { BCS, HexString, TxnBuilderTypes} from "aptos";
+import { APTOS_TOKEN as APTOS_COIN } from "../web3/transaction";
 import {Transaction} from "../web3/transaction";
 import {HexBuffer} from "../utils/buffer";
 import {DEPLOYER} from "../web3/global";

--- a/src/momentum-safe/common.ts
+++ b/src/momentum-safe/common.ts
@@ -1,8 +1,8 @@
-import { BCS, HexString, TxnBuilderTypes} from "aptos";
+import { BCS, HexString, TxnBuilderTypes } from "aptos";
 import { APTOS_TOKEN as APTOS_COIN } from "../web3/transaction";
-import {Transaction} from "../web3/transaction";
-import {HexBuffer} from "../utils/buffer";
-import {DEPLOYER} from "../web3/global";
+import { Transaction } from "../web3/transaction";
+import { HexBuffer } from "../utils/buffer";
+import { DEPLOYER } from "../web3/global";
 
 
 export const APTOS_FRAMEWORK = '0x0000000000000000000000000000000000000000000000000000000000000001';
@@ -43,26 +43,35 @@ export const FUNCTIONS = {
 export const STRUCTS = {
   MOMENTUM: "Momentum",
   MOMENTUM_TRANSACTION: "Transaction",
+  MOMENTUM_EVENT: "MomentumSafeEvent",
   CREATOR: "PendingMultiSigCreations",
   CREATOR_CREATION: "MomentumSafeCreation",
+  CREATOR_EVENT: "MultiSigCreationEvent",
   REGISTRY: "OwnerMomentumSafes",
+  REGISTRY_EVENT: "RegisterEvent",
   APTOS_COIN: "AptosCoin",
   COIN_INFO: "CoinInfo"
-};
+} as const;
 
 // TODO: refactor all these values
-export function getResourceTag(tagName: string): string {
+export function getResourceTag(tagName: keyof typeof STRUCTS): string {
   switch (tagName) {
     case ('MOMENTUM'):
       return `${DEPLOYER}::${MODULES.MOMENTUM_SAFE}::${STRUCTS.MOMENTUM}`;
     case ('MOMENTUM_TRANSACTION'):
       return `${DEPLOYER}::${MODULES.MOMENTUM_SAFE}::${STRUCTS.MOMENTUM_TRANSACTION}`;
+    case ('MOMENTUM_EVENT'):
+      return `${DEPLOYER}::${MODULES.MOMENTUM_SAFE}::${STRUCTS.MOMENTUM_EVENT}`;
     case ('CREATOR'):
       return `${DEPLOYER}::${MODULES.CREATOR}::${STRUCTS.CREATOR}`;
     case ('CREATOR_CREATION'):
       return `${DEPLOYER}::${MODULES.CREATOR}::${STRUCTS.CREATOR_CREATION}`;
+    case ('CREATOR_EVENT'):
+      return `${DEPLOYER}::${MODULES.CREATOR}::${STRUCTS.CREATOR_EVENT}`;
     case ('REGISTRY'):
       return `${DEPLOYER}::${MODULES.REGISTRY}::${STRUCTS.REGISTRY}`;
+    case ('REGISTRY_EVENT'):
+      return `${DEPLOYER}::${MODULES.REGISTRY}::${STRUCTS.REGISTRY_EVENT}`;
     case ('APTOS_COIN'):
       return `${APTOS_COIN}::${MODULES.COIN}::${STRUCTS.APTOS_COIN}`;
   }

--- a/src/momentum-safe/msafe-txn.ts
+++ b/src/momentum-safe/msafe-txn.ts
@@ -1,7 +1,6 @@
 import {AptosCoinTransferTxnBuilder, AptosEntryTxnBuilder, Transaction} from "../web3/transaction";
 import {BCS, HexString, TransactionBuilder, TxnBuilderTypes} from "aptos";
 import * as Aptos from '../web3/global';
-import {Buffer} from "buffer/";
 import {
   APTOS_FRAMEWORK_HS,
   FUNCTIONS,

--- a/src/momentum-safe/msafe-txn.ts
+++ b/src/momentum-safe/msafe-txn.ts
@@ -9,9 +9,9 @@ import {
   Options,
   STRUCTS, TxConfig
 } from "./common";
-import * as SHA3 from "js-sha3";
 import {IncludedArtifacts, MovePublisher, PackageMetadata} from "./move-publisher";
 import {sha3_256} from "../utils/crypto";
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import {secToDate, typeTagStructFromName} from "../utils/parse";
 import {isHexEqual} from "../utils/check";
 import {DEPLOYER} from "../web3/global";
@@ -626,8 +626,8 @@ function decodeModulePublishArgs(payload: TxnBuilderTypes.TransactionPayloadEntr
 }
 
 function getModulePublishHash(metadataRaw: Uint8Array, codes: Uint8Array): HexString {
-  const hash = SHA3.sha3_256.create();
+  const hash = sha3Hash.create();
   hash.update(metadataRaw);
   hash.update(codes);
-  return new HexString(hash.hex());
+  return HexString.fromUint8Array(hash.digest());
 }

--- a/src/momentum-safe/registry.ts
+++ b/src/momentum-safe/registry.ts
@@ -1,4 +1,4 @@
-import {ApiError, BCS, HexString} from "aptos";
+import { ApiError, BCS, HexString } from "aptos";
 import * as Aptos from "../web3/global";
 import {
   FUNCTIONS,
@@ -6,16 +6,22 @@ import {
   vector,
   HexStr, getResourceTag,
 } from "./common";
-import {Account} from "../web3/account";
-import {AptosEntryTxnBuilder} from "../web3/transaction";
-import {formatAddress} from "../utils/parse";
-import {DEPLOYER} from "../web3/global";
+import { Account } from "../web3/account";
+import { AptosEntryTxnBuilder } from "../web3/transaction";
+import { formatAddress } from "../utils/parse";
+import { DEPLOYER } from "../web3/global";
+import { EventHandle, PaginationArgs } from "../moveTypes/moveEvent";
 
 // Data in registry
 type OwnerMomentumSafes = {
   public_key: string,
   pendings: vector<HexStr>,
   msafes: vector<HexStr>,
+}
+
+
+export type RegisterEvent = {
+  events: EventHandle<OwnerMomentumSafes>
 }
 
 export class Registry {
@@ -34,8 +40,8 @@ export class Registry {
     const ownedMSafes = res.data as OwnerMomentumSafes;
     return {
       publicKey: HexString.ensure(ownedMSafes.public_key),
-      pendings: ownedMSafes.pendings.map( (addr) => formatAddress(addr)),
-      msafes:  ownedMSafes.msafes.map( (addr) => formatAddress(addr) ),
+      pendings: ownedMSafes.pendings.map((addr) => formatAddress(addr)),
+      msafes: ownedMSafes.msafes.map((addr) => formatAddress(addr)),
     };
   }
 
@@ -80,4 +86,14 @@ export class Registry {
       ])
       .build();
   }
+
+  static async getRegisterEvent(owner: HexString): Promise<RegisterEvent> {
+    const eventStruct = await Aptos.getAccountResource(owner, getResourceTag('REGISTRY_EVENT'));
+    return eventStruct.data as any;
+  }
+
+  static async filterRegisterEvent(eventStruct: RegisterEvent, option: PaginationArgs) {
+    return Aptos.filterEvent(eventStruct.events, option);
+  }
+
 }

--- a/src/moveTypes/moveEvent.ts
+++ b/src/moveTypes/moveEvent.ts
@@ -1,0 +1,29 @@
+import {AptosClient, Types} from "aptos";
+
+export type GUID = {
+    id: ID
+};
+
+/// A non-privileged identifier that can be freely created by anyone. Useful for looking up GUID's.
+export type ID = {
+    /// If creation_num is `i`, this is the `i+1`th GUID created by `addr`
+    creation_num: Types.U64,
+    /// Address that created the GUID
+    addr: Types.Address
+};
+
+export type EventHandle<T> = {
+    /// Total number of events emitted to this event stream.
+    counter: Types.U64,
+    /// A globally unique ID for this event stream.
+    guid: GUID,
+};
+export type AnyNumber = bigint | number;
+export type PaginationArgs = {
+    start?: AnyNumber;
+    limit?: number;
+}
+
+export type Event<T> = Omit<Types.VersionedEvent, 'data'> & {data:T};
+
+

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,4 +1,3 @@
-import {Buffer} from "buffer/";
 import {HexString} from "aptos";
 
 export function HexBuffer(hex: HexString | string): Buffer {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -3,7 +3,6 @@ import {
   HexString,
   BCS
 } from "aptos";
-import {Buffer} from "buffer/"; // the trailing slash is important!
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import * as Aptos from "../web3/global";
 import {HexBuffer} from "./buffer";

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -4,7 +4,7 @@ import {
   BCS
 } from "aptos";
 import {Buffer} from "buffer/"; // the trailing slash is important!
-import * as SHA3 from "js-sha3";
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import * as Aptos from "../web3/global";
 import {HexBuffer} from "./buffer";
 
@@ -54,15 +54,15 @@ function noncePubKey(nonce: number) {
 
 
 export function deriveAuthKey(publicKey: HexString): HexString {
-  const hash = SHA3.sha3_256.create();
+  const hash = sha3Hash.create();
   hash.update(publicKey.toUint8Array());
   hash.update("\x00");
-  return new HexString(hash.hex());
+  return HexString.fromUint8Array(hash.digest());
 }
 
 // Used to calculate the temporary hash of the transaction payload
 export function sha3_256(payload: Uint8Array): HexString {
-  const hash = SHA3.sha3_256.create();
+  const hash = sha3Hash.create();
   hash.update(payload);
-  return new HexString(hash.hex());
+  return HexString.fromUint8Array(hash.digest());
 }

--- a/src/web3/global.ts
+++ b/src/web3/global.ts
@@ -14,7 +14,6 @@ import { BigNumber } from "bignumber.js";
 import { bigIntToBigNumber, fromDust } from "../utils/bignumber";
 import {getDeployedAddrFromNodeURL} from "./config";
 import { AnyNumber, Event, EventHandle, PaginationArgs } from '../moveTypes/moveEvent';
-import { Transaction_UserTransaction, UserTransaction } from 'aptos/src/generated';
 
 export let MY_ACCOUNT: Account;
 export let APT_COIN_INFO: Coin;
@@ -162,11 +161,11 @@ export async function filterEvent<T>(handle: EventHandle<T>, option?: Pagination
   return await APTOS.getEventsByCreationNumber(handle.guid.id.addr, handle.guid.id.creation_num, option) as any;
 }
 
-export async function getTransactionByVersion(version: AnyNumber): Promise<Transaction_UserTransaction> {
+export async function getTransactionByVersion(version: AnyNumber): Promise<Types.Transaction_UserTransaction> {
   return APTOS.getTransactionByVersion(version) as any;
 }
 
-export async function getTransactionByEvent<T>(event: Event<T>): Promise<Transaction_UserTransaction> {
+export async function getTransactionByEvent<T>(event: Event<T>): Promise<Types.Transaction_UserTransaction> {
   return getTransactionByVersion(BigInt(event.version));
 }
 

--- a/src/web3/global.ts
+++ b/src/web3/global.ts
@@ -13,6 +13,8 @@ import { Coin } from "./coin";
 import { BigNumber } from "bignumber.js";
 import { bigIntToBigNumber, fromDust } from "../utils/bignumber";
 import {getDeployedAddrFromNodeURL} from "./config";
+import { AnyNumber, Event, EventHandle, PaginationArgs } from '../moveTypes/moveEvent';
+import { Transaction_UserTransaction, UserTransaction } from 'aptos/src/generated';
 
 export let MY_ACCOUNT: Account;
 export let APT_COIN_INFO: Coin;
@@ -154,6 +156,18 @@ async function loadAptosYaml(filePath: string) {
 
 export async function getAccountModule(addr: HexString, moduleName: string) {
   return await APTOS.getAccountModule(addr, moduleName);
+}
+
+export async function filterEvent<T>(handle: EventHandle<T>, option?: PaginationArgs):Promise<Event<T>[]> {
+  return await APTOS.getEventsByCreationNumber(handle.guid.id.addr, handle.guid.id.creation_num, option) as any;
+}
+
+export async function getTransactionByVersion(version: AnyNumber): Promise<Transaction_UserTransaction> {
+  return APTOS.getTransactionByVersion(version) as any;
+}
+
+export async function getTransactionByEvent<T>(event: Event<T>): Promise<Transaction_UserTransaction> {
+  return getTransactionByVersion(BigInt(event.version));
 }
 
 export function client() {

--- a/src/web3/transaction.ts
+++ b/src/web3/transaction.ts
@@ -4,7 +4,6 @@ import {
   TransactionBuilder,
   TxnBuilderTypes,
 } from "aptos";
-import {Buffer} from "buffer/";
 
 const COIN_MODULE = "0x1::coin";
 const TRANSFER_METHOD = "transfer";

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,16 +560,15 @@ append-transform@^2.0.0:
   dependencies:
     default-require-extensions "^3.0.0"
 
-aptos@^1.3.13:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/aptos/-/aptos-1.3.13.tgz#cbf12431b6ee66a3d1952b1d1ce6520005170da0"
-  integrity sha512-rhpG9ibIWZxMLsUY91bSCeN75H68onvms/gTDaWRKkryOAVdzPUmvWd34TQN8uFjNZRFlXloIICm/8Ri+yBRNw==
+aptos@^1.3.15:
+  version "1.3.15"
+  resolved "https://registry.yarnpkg.com/aptos/-/aptos-1.3.15.tgz#700bb78c1f04de78d2518d2dd9d9e675aef0d8e2"
+  integrity sha512-kRjTHZctWM5m4K1tMDl7tZZpRu0+ceHFGpvyMw8ONrtbx9EvfcctFSv9DnSKSKGX0soivT0LhwDFIobd3jQQtw==
   dependencies:
     "@noble/hashes" "1.1.2"
     "@scure/bip39" "1.1.0"
     axios "0.27.2"
     form-data "4.0.0"
-    js-sha3 "0.8.0"
     tweetnacl "1.0.3"
 
 archy@^1.0.0:
@@ -1494,11 +1493,6 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
-
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
All event query function name have prefix `filter`,  for example: `filterRegisterEvent(...)`;
To query for an event, you need to know which struct the event is included in and which account the struct stored in.
For example, MomentumSafeEvent has 2 events, and it store into BOB account '0xB0B': 
```move
struct MomentumSafeEvent has key {
    register_events: EventHandle<Info>,
    transaction_events: EventHandle<Transaction>
}
```
first, you should get this resource from BOB, like:
```ts
type MomentumSafeEvent = {
  register_events: EventHandle<Info>,
  transaction_events: EventHandle<TransactionType>
}
const bobEventStruct:MomentumSafeEvent = await MomentumSafe.getMomentumSafeEvent('0xB0B');
```
then, query event that you want:
```ts
type Event = XXX;
const registerEvents:Event[] = await MomentumSafe.filterRegisterEvent(bobEventStruct.register_events);
const transactionEvents:Event[] = await MomentumSafe.filterRegisterEvent(bobEventStruct.transaction_events);
```
get transaction by event:
```ts
const tx:Transaction_UserTransaction = await Aptos.getTransactionByEvent(registerEvents[0]);
```