### PR TITLE
[cmd] add formatting for address type with 0x1

### DIFF
--- a/src/cmd/new-transaction.ts
+++ b/src/cmd/new-transaction.ts
@@ -40,7 +40,7 @@ import {
   isStringHex,
   isStringTypeStruct
 } from "../utils/check";
-import {splitModuleComponents} from "../utils/parse";
+import {formatToFullType, splitModuleComponents} from "../utils/parse";
 import {BigNumber} from "bignumber.js";
 import {toDust} from "../utils/bignumber";
 
@@ -300,7 +300,7 @@ async function promptForTypeArgs() {
       "\tInvalid type arg:\t",
       isStringTypeStruct,
     );
-    tyArgs.push(ta);
+    tyArgs.push(formatToFullType(ta));
   }
   return tyArgs;
 }

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -62,3 +62,13 @@ export function secToDate(sec: BCS.Uint64) {
   const ms = Number(sec) * 1000;
   return new Date(ms);
 }
+
+export function formatToFullType(coinType: string) {
+  const [
+    address,
+    module,
+    struct,
+  ] = coinType.split("::");
+  const shortAddr = address.startsWith("0x") ? address.slice(2) : address;
+  return `0x${shortAddr.padStart(ADDRESS_HEX_LENGTH, "0")}::${module}::${struct}`;
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/Momentum-Safe/CLI-MSafe/issues/38

Add formatting for short type E.g. 0x1::aptos_coin::AptosCoin -> 0x0000...1::aptos_coin::AptosCoin